### PR TITLE
doctors.csv: Use composite index instead of generated sequential id

### DIFF
--- a/update.py
+++ b/update.py
@@ -59,9 +59,7 @@ def convert_to_csv():
     doctors.sort_values(by=[*doctors], inplace=True) # sort by all columns
 
     # reindex:
-    doctors = doctors.apply(list).reset_index()
-    doctors.drop('index', axis='columns', inplace=True)
-    doctors.index.rename('id', inplace=True)
+    doctors.set_index(['doctor','type','id_inst'], inplace=True)
 
     doctors.to_csv('csv/doctors.csv')
 


### PR DESCRIPTION
Generated `id` index field is no longer needed after https://github.com/sledilnik/zdravniki/pull/119

This should generate nicer diffs when updating instead of unreadable (eg 3b16ddc28c81d3f1587890c4485cd2ddb0d8d8eb)