### PR TITLE
Bump python from 3.8 to 3.11

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -37,7 +37,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.11'
 
     - name: Cache pip
       uses: actions/cache@v3.2.6


### PR DESCRIPTION
To get bugfixes, not just security fixes. 

See https://devguide.python.org/versions/