### PR TITLE
Handle 15-column zdravniki Excel format

### DIFF
--- a/update.py
+++ b/update.py
@@ -97,8 +97,7 @@ def convert_to_csv(zzzsid_map):
                 df['accepts'] = 'DA'
                 
             else:
-                print(f"Unsupported v-dodatnih-ambulantah source columns! count={len(df.columns)}: {df.columns}")
-                raise
+                raise ValueError(f"Unsupported v-dodatnih-ambulantah source columns! count={len(df.columns)}: {df.columns}")
 
         elif group == "za-boljšo-dostopnost":
             print("Converting za boljšo dostopnost")
@@ -118,11 +117,17 @@ def convert_to_csv(zzzsid_map):
 
         else:
             print("Converting doctors list")
-            if len(df.columns) == 12 or len(df.columns) == 13 or len(df.columns) == 14 or len(df.columns) == 16:
+            if len(df.columns) in (12, 13, 14, 15, 16):
                 print("...version after 2023-02-10")
 
                 if len(df.columns) == 14 or len(df.columns) == 13:
                     print("...version after 2024-05-10: ignore new 'Specializant' column")
+                    df.drop(columns=['Specializant'], inplace=True)
+
+                if len(df.columns) == 15:
+                    print("...version after 2026-06-22: ignore 3 new columns for now")
+                    df.drop(columns=['Zdravnik mora  glede na št. opredeljenih oseb (stolpec M) sprejeti novorojenčke in dojenčke (otroci do enega leta)'], inplace=True)
+                    df.drop(columns=['Število opredeljenih oseb  preračunano na 1 tim zaposlitve'], inplace=True)
                     df.drop(columns=['Specializant'], inplace=True)
 
                 if len(df.columns) == 16:
@@ -144,8 +149,7 @@ def convert_to_csv(zzzsid_map):
                 # TODO: insert dummy new ID columns if needed.
 
             else:
-                print(f"Unsupported za opredeljene source columns! count={len(df.columns)}: {df.columns}")
-                raise
+                raise ValueError(f"Unsupported za opredeljene source columns! count={len(df.columns)}: {df.columns}")
 
 
         df['doctor'] = df['doctor'].str.strip().replace('\s+', ' ', regex=True)


### PR DESCRIPTION
ZZZS changed the "zdravniki" spreadsheet from 13 to 15 columns ([failed run](https://github.com/sledilnik/zdravniki-data/actions/runs/27970093490/job/82773792293)), adding two new columns that the parser didn't expect. This caused `update.py` to fall into the unsupported-column-count branch and crash.

**What changed:**

- Added handling for 15-column format by dropping the 3 extra columns (`Zdravnik mora...sprejeti novorojenčke`, `Število opredeljenih oseb preračunano na 1 tim zaposlitve`, and `Specializant`) to restore the expected 12-column layout
- Replaced bare `raise` statements (which produced the unhelpful `RuntimeError: No active exception to reraise`) with `raise ValueError(...)` containing a descriptive message, so future format changes produce clear errors