### PR TITLE
Fix: defer dropna() until after column drops to keep GP doctors

### DIFF
--- a/update.py
+++ b/update.py
@@ -81,7 +81,7 @@ def convert_to_csv(zzzsid_map):
         else:
             sheet="Podatki"
             skipr=9
-        df = pd.read_excel(io=filename, sheet_name=sheet, skiprows=skipr).dropna()
+        df = pd.read_excel(io=filename, sheet_name=sheet, skiprows=skipr).dropna(how='all')
 
         if group == "v-dodatnih-ambulantah":
             print("Converting v dodatnih ambulantah")
@@ -152,6 +152,7 @@ def convert_to_csv(zzzsid_map):
                 raise ValueError(f"Unsupported za opredeljene source columns! count={len(df.columns)}: {df.columns}")
 
 
+        df = df.dropna()
         df['doctor'] = df['doctor'].str.strip().replace('\s+', ' ', regex=True)
         df['type'] = df['type'].str.strip().map(type_map)
         df['accepts'] = df['accepts'].str.strip().map(accepts_map)


### PR DESCRIPTION
## Problem

Since #88 merged, most GP doctors (~1450 out of 1460) are missing from the output.

**Root cause**: The new 15-column zdravniki format has a "novorojenčke" column that is `NaN` for most rows (1450/1460). Since `.dropna()` was called on line 84 *before* the column-specific handling removed it, almost all rows were eliminated.

## Fix

Two-line change:
1. Replace `.dropna()` with `.dropna(how='all')` on read — only removes fully empty padding rows
2. Add `df = df.dropna()` *after* the column-specific processing drops the problematic columns

## Result

| Group | Before fix | After fix |
|-------|-----------|-----------|
| zdravniki (GP) | 10 rows | 1456 rows ✅ |
| zobozdravniki | 1287 | 1287 (unchanged) |
| ginekologi | 351 | 351 (unchanged) |
| v-dodatnih-ambulantah | 34 | 34 (unchanged) |