### PR TITLE
Fix: exclude availability from dropna to keep Dodatna ambulanta

### DIFF
--- a/update.py
+++ b/update.py
@@ -152,7 +152,7 @@ def convert_to_csv(zzzsid_map):
                 raise ValueError(f"Unsupported za opredeljene source columns! count={len(df.columns)}: {df.columns}")
 
 
-        df = df.dropna()
+        df = df.dropna(subset=[c for c in df.columns if c != 'availability'])
         df['doctor'] = df['doctor'].str.strip().replace('\s+', ' ', regex=True)
         df['type'] = df['type'].str.strip().map(type_map)
         df['accepts'] = df['accepts'].str.strip().map(accepts_map)


### PR DESCRIPTION
## Problem

After #89, the `df.dropna()` added after column processing also drops all "Dodatna ambulanta" rows because their `availability` column is intentionally set to `None` (line 96).

## Fix

Use `df.dropna(subset=[c for c in df.columns if c != 'availability'])` so that NaN in the `availability` column doesn't cause rows to be dropped.

## Result

| Group | Before | After |
|-------|--------|-------|
| zdravniki (GP) | 1456 | 1456 ✅ |
| v-dodatnih-ambulantah | 0 ❌ | 34 ✅ |
| zobozdravniki | 1287 | 1287 |
| ginekologi | 351 | 351 |